### PR TITLE
Add tournament table placeholder page

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -10,6 +10,7 @@ import {
   RulesPage,
   PromptGalleryPage,
   AccountPage,
+  TournamentTablePage,
   AdTechPage,
   FintechPage,
   MediaPage,
@@ -29,6 +30,7 @@ export const router = createBrowserRouter([
   { path: "/interview", element: <InterviewPage /> },
   { path: "/work", element: <WorkAtMtsPage /> },
   { path: "/gallery", element: <PromptGalleryPage /> },
+  { path: "/tournament-table", element: <TournamentTablePage /> },
 
   // --- activities ---
   { path: "/activities/adtech", element: <AdTechPage /> },

--- a/src/pages/TournamentTablePage/index.tsx
+++ b/src/pages/TournamentTablePage/index.tsx
@@ -1,0 +1,16 @@
+import type { FC } from "react";
+import { Text } from "@chernyshovaalexandra/mtsui";
+import { Section } from "../../shared";
+import { MainLayout } from "../../layouts";
+
+const TournamentTablePage: FC = () => (
+  <MainLayout>
+    <Section title="Рейтинг участников">
+      <Text variant="P4-Regular-Text">
+        Здесь будет информация о рейтинге участников.
+      </Text>
+    </Section>
+  </MainLayout>
+);
+
+export default TournamentTablePage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -13,6 +13,7 @@ export { default as ServicePage } from "./ServicePage";
 export { default as ITPage } from "./ITPage";
 export { default as FinancePage } from "./FinancePage";
 export { default as AccountPage } from "./AccountPage";
+export { default as TournamentTablePage } from "./TournamentTablePage";
 
 // --- Activities ---
 export { default as AdTechPage } from "./activities/adtech";


### PR DESCRIPTION
## Summary
- create `TournamentTablePage` as an accessible placeholder
- register the page in router
- export the page from `pages` index

## Testing
- `pnpm lint` *(fails: fetch 403 due to lack of internet)*

------
https://chatgpt.com/codex/tasks/task_e_68872755c8bc8323b11d6828b5204038