### PR TITLE
Add global user store

### DIFF
--- a/docs/account-page.md
+++ b/docs/account-page.md
@@ -39,7 +39,7 @@ interface PersonalDataCardProps {
 
 interface TablePositionCardProps {
   position: number;
-  points: string;
+  points: number;
   onViewRating: () => void;
 }
 
@@ -154,7 +154,7 @@ interface PersonalDataCardProps {
 ```typescript
 interface TablePositionCardProps {
   position: number;
-  points: string;
+  points: number;
   onViewRating: () => void;
 }
 ```

--- a/src/entities/TablePositionCard/index.tsx
+++ b/src/entities/TablePositionCard/index.tsx
@@ -9,12 +9,12 @@ import { ACCOUNTPAGE_BTN_THEME } from "../../pages/AccountPage/constants";
 /**
  * @typedef {Object} TablePositionCardProps
  * @property {number} position - Позиция в таблице рейтинга
- * @property {string} points - Количество баллов
+ * @property {number} points - Количество баллов
  * @property {() => void} onViewRating - Обработчик клика по кнопке просмотра рейтинга
  */
 interface TablePositionCardProps {
   position: number;
-  points: string;
+  points: number;
   onViewRating: () => void;
 }
 
@@ -61,8 +61,8 @@ const TablePositionCard: FC<TablePositionCardProps> = ({
 
       <DataRow>
         <FieldLabel>Баллы</FieldLabel>
-        <FieldValue aria-label={`Количество баллов: ${points}`}>
-          {points}
+        <FieldValue aria-label={`Количество баллов: ${points.toLocaleString("ru")}`}>
+          {points.toLocaleString("ru")}
         </FieldValue>
       </DataRow>
 

--- a/src/pages/AccountPage/constants/index.ts
+++ b/src/pages/AccountPage/constants/index.ts
@@ -15,7 +15,7 @@ export const ACCOUNT_PAGE_DATA: AccountPageData = {
   },
   tablePosition: {
     position: 1367,
-    points: "XXXX",
+    points: 15083,
   },
   interviewSimulation: {
     direction: "Работа в IT",

--- a/src/pages/AccountPage/index.tsx
+++ b/src/pages/AccountPage/index.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react";
-import { useMemo } from "react";
 import { MainLayout } from "../../layouts";
-import { ACCOUNT_PAGE_DATA } from "./constants";
+import { useUserStore } from "../../store";
 import { useAccountPageHandlers } from "./hooks";
 import {
   AccountPageLayout,
@@ -21,8 +20,7 @@ import {
  */
 const AccountPage: FC = () => {
   const handlers = useAccountPageHandlers();
-
-  const pageData = useMemo(() => ACCOUNT_PAGE_DATA, []);
+  const pageData = useUserStore((s) => s.data);
 
   return (
     <MainLayout>

--- a/src/pages/AccountPage/types/index.ts
+++ b/src/pages/AccountPage/types/index.ts
@@ -8,7 +8,7 @@ export interface PersonalData {
 
 export interface TablePosition {
   position: number;
-  points: string;
+  points: number;
 }
 
 export interface InterviewSimulation {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,1 +1,2 @@
 export * from "./useModalStore";
+export * from "./useUserStore";

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { ACCOUNT_PAGE_DATA } from "../pages/AccountPage/constants";
+import type { AccountPageData } from "../pages/AccountPage/types";
+
+interface UserState {
+  isAuth: boolean;
+  data: AccountPageData;
+  setAccountData: (data: AccountPageData) => void;
+  logout: () => void;
+}
+
+export const useUserStore = create<UserState>((set) => ({
+  isAuth: true,
+  data: ACCOUNT_PAGE_DATA,
+  setAccountData: (data) => set({ data, isAuth: true }),
+  logout: () => set({ isAuth: false, data: ACCOUNT_PAGE_DATA }),
+}));

--- a/src/widgets/Header/index.tsx
+++ b/src/widgets/Header/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "@chernyshovaalexandra/mtsui";
 import type { FC } from "react";
 import { useRef, useState } from "react";
+import { useUserStore } from "../../store";
 import { useNavigate } from "react-router-dom";
 import { Bar, Nav, NavItem, Spacer, Score, IconBtn, Surface } from "./style";
 
@@ -25,10 +26,12 @@ export const Header: FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement>(null);
 
-  /* TODO: подключить реальное состояние авторизации */
-  const isAuth = false;
-  const userName = "Имя Фамилия";
-  const userScore = 15_083;
+  const isAuth = useUserStore((s) => s.isAuth);
+  const user = useUserStore((s) => s.data);
+  const userName = user
+    ? `${user.personalData.firstName} ${user.personalData.lastName}`
+    : "";
+  const userScore = user?.tablePosition.points ?? 0;
 
   /* handlers */
   const handleLogin = () => navigate("/login");
@@ -116,7 +119,7 @@ export const Header: FC = () => {
             variant="secondary"
             style={{ margin: 12 }}
             onClick={() => {
-              /* TODO logout */
+              useUserStore.getState().logout();
               closeMenu();
             }}
           >


### PR DESCRIPTION
## Summary
- introduce `useUserStore` with default data from AccountPage
- link header and account page to the new store
- treat rating points as number
- update docs and types

## Testing
- `pnpm lint` *(fails: unable to download packages)*
- `pnpm build` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68873b5d8a0c8323844190f95944e0db