### PR TITLE
Add QuizQuestion component skeleton

### DIFF
--- a/src/features/quiz/components/QuizQuestion/QuizQuestion.tsx
+++ b/src/features/quiz/components/QuizQuestion/QuizQuestion.tsx
@@ -1,0 +1,7 @@
+import type { FC } from "react";
+import { QuizQuestionWrapper } from "./style";
+import type { QuizQuestionProps } from "./types";
+
+export const QuizQuestion: FC<QuizQuestionProps> = () => {
+  return <QuizQuestionWrapper />;
+};

--- a/src/features/quiz/components/QuizQuestion/style.ts
+++ b/src/features/quiz/components/QuizQuestion/style.ts
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const QuizQuestionWrapper = styled.div``;
+export const AnswersList = styled.ul``;
+export const AnswerItem = styled.li``;

--- a/src/features/quiz/components/QuizQuestion/types.ts
+++ b/src/features/quiz/components/QuizQuestion/types.ts
@@ -1,0 +1,10 @@
+export interface Answer {
+  id: string;
+  text: string;
+}
+
+export interface QuizQuestionProps {
+  question: string;
+  answers: Answer[];
+  onAnswer?: (id: string) => void;
+}


### PR DESCRIPTION
## Summary
- scaffold `QuizQuestion` component inside `features/quiz`
- add placeholder styled blocks
- declare `Answer` and `QuizQuestionProps` interfaces

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npx tsc -p tsconfig.app.json` *(fails: cannot find modules such as 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_688742cda1c08323afba1af81d8443d6