### PR TITLE
Add event stream page

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -9,6 +9,7 @@ import {
   WorkAtMtsPage,
   RulesPage,
   PromptGalleryPage,
+  StreamPage,
   AccountPage,
   TournamentTablePage,
   AdTechPage,
@@ -30,6 +31,7 @@ export const router = createBrowserRouter([
   { path: "/interview", element: <InterviewPage /> },
   { path: "/work", element: <WorkAtMtsPage /> },
   { path: "/gallery", element: <PromptGalleryPage /> },
+  { path: "/stream", element: <StreamPage /> },
   { path: "/tournament-table", element: <TournamentTablePage /> },
 
   // --- activities ---

--- a/src/pages/StreamPage/index.tsx
+++ b/src/pages/StreamPage/index.tsx
@@ -1,0 +1,29 @@
+import type { FC } from "react";
+import { MainLayout } from "../../layouts";
+import { Section } from "../../shared";
+
+const StreamPage: FC = () => (
+  <MainLayout>
+    <Section title="Трансляция мероприятия" align="center">
+      <div style={{ position: "relative", width: "100%", paddingBottom: "56.25%" }}>
+        <iframe
+          src="https://www.youtube.com/embed/live_stream?channel=CHANNEL_ID"
+          title="Трансляция"
+          allow="autoplay; encrypted-media"
+          allowFullScreen
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            border: 0,
+            borderRadius: 16,
+          }}
+        />
+      </div>
+    </Section>
+  </MainLayout>
+);
+
+export default StreamPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -13,6 +13,7 @@ export { default as ServicePage } from "./ServicePage";
 export { default as ITPage } from "./ITPage";
 export { default as FinancePage } from "./FinancePage";
 export { default as AccountPage } from "./AccountPage";
+export { default as StreamPage } from "./StreamPage";
 export { default as TournamentTablePage } from "./TournamentTablePage";
 
 // --- Activities ---

--- a/src/widgets/Header/index.tsx
+++ b/src/widgets/Header/index.tsx
@@ -17,6 +17,7 @@ import { Bar, Nav, NavItem, Spacer, Score, IconBtn, Surface } from "./style";
 
 const navLinks = [
   { title: "Правила участия", url: "/rules" },
+  { title: "Трансляция", url: "/stream" },
   { title: "Задать вопрос", url: "/faq" },
   { title: "Рейтинг участников", url: "/tournament-table" },
 ];


### PR DESCRIPTION
## Summary
- add StreamPage for live event streaming
- link new StreamPage in router
- expose StreamPage from pages index
- add header nav item to StreamPage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688744e651e483238ab8fa362b931a0e