### PR TITLE
Add quiz component to activity pages

### DIFF
--- a/src/pages/FinancePage/index.tsx
+++ b/src/pages/FinancePage/index.tsx
@@ -2,6 +2,8 @@ import type { FC } from "react";
 import { Text } from "@chernyshovaalexandra/mtsui";
 import { Section } from "../../shared";
 import { MainLayout } from "../../layouts";
+import { Quiz } from "../../widgets";
+import { financeQuestions } from "./questions";
 
 const FinancePage: FC = () => (
   <MainLayout>
@@ -9,6 +11,7 @@ const FinancePage: FC = () => (
       <Text variant="P4-Regular-Text">
         Здесь будет информация о направлении "Финансы".
       </Text>
+      <Quiz questions={financeQuestions} />
     </Section>
   </MainLayout>
 );

--- a/src/pages/FinancePage/questions.ts
+++ b/src/pages/FinancePage/questions.ts
@@ -1,0 +1,9 @@
+import type { QuizQuestion } from "../../widgets/Quiz";
+
+export const financeQuestions: QuizQuestion[] = [
+  {
+    question: "Что такое баланс?",
+    options: ["Отчет о доходах", "Соотношение активов и пассивов", "Кредит"],
+    correct: 1,
+  },
+];

--- a/src/pages/ITPage/index.tsx
+++ b/src/pages/ITPage/index.tsx
@@ -2,6 +2,8 @@ import type { FC } from "react";
 import { Text } from "@chernyshovaalexandra/mtsui";
 import { Section } from "../../shared";
 import { MainLayout } from "../../layouts";
+import { Quiz } from "../../widgets";
+import { itQuestions } from "./questions";
 
 const ITPage: FC = () => (
   <MainLayout>
@@ -9,6 +11,7 @@ const ITPage: FC = () => (
       <Text variant="P4-Regular-Text">
         Здесь будет информация о направлении "IT".
       </Text>
+      <Quiz questions={itQuestions} />
     </Section>
   </MainLayout>
 );

--- a/src/pages/ITPage/questions.ts
+++ b/src/pages/ITPage/questions.ts
@@ -1,0 +1,9 @@
+import type { QuizQuestion } from "../../widgets/Quiz";
+
+export const itQuestions: QuizQuestion[] = [
+  {
+    question: "Что такое алгоритм?",
+    options: ["Последовательность действий", "Программа", "Устройство"],
+    correct: 0,
+  },
+];

--- a/src/pages/MarketingPage/index.tsx
+++ b/src/pages/MarketingPage/index.tsx
@@ -2,6 +2,8 @@ import type { FC } from "react";
 import { Text } from "@chernyshovaalexandra/mtsui";
 import { Section } from "../../shared";
 import { MainLayout } from "../../layouts";
+import { Quiz } from "../../widgets";
+import { marketingQuestions } from "./questions";
 
 const MarketingPage: FC = () => (
   <MainLayout>
@@ -9,6 +11,7 @@ const MarketingPage: FC = () => (
       <Text variant="P4-Regular-Text">
         Здесь будет информация о направлении "Маркетинг и коммуникации".
       </Text>
+      <Quiz questions={marketingQuestions} />
     </Section>
   </MainLayout>
 );

--- a/src/pages/MarketingPage/questions.ts
+++ b/src/pages/MarketingPage/questions.ts
@@ -1,0 +1,9 @@
+import type { QuizQuestion } from "../../widgets/Quiz";
+
+export const marketingQuestions: QuizQuestion[] = [
+  {
+    question: "Что изучает маркетинг?",
+    options: ["Рынок и потребителей", "Только рекламу", "Только продажи"],
+    correct: 0,
+  },
+];

--- a/src/pages/ServicePage/index.tsx
+++ b/src/pages/ServicePage/index.tsx
@@ -2,6 +2,8 @@ import type { FC } from "react";
 import { Text } from "@chernyshovaalexandra/mtsui";
 import { Section } from "../../shared";
 import { MainLayout } from "../../layouts";
+import { Quiz } from "../../widgets";
+import { serviceQuestions } from "./questions";
 
 const ServicePage: FC = () => (
   <MainLayout>
@@ -9,6 +11,7 @@ const ServicePage: FC = () => (
       <Text variant="P4-Regular-Text">
         Здесь будет информация о направлении "Сервис и услуги".
       </Text>
+      <Quiz questions={serviceQuestions} />
     </Section>
   </MainLayout>
 );

--- a/src/pages/ServicePage/questions.ts
+++ b/src/pages/ServicePage/questions.ts
@@ -1,0 +1,9 @@
+import type { QuizQuestion } from "../../widgets/Quiz";
+
+export const serviceQuestions: QuizQuestion[] = [
+  {
+    question: "Что относится к сервису?",
+    options: ["Поддержка клиентов", "Производство", "Разработка"],
+    correct: 0,
+  },
+];

--- a/src/widgets/Quiz/Quiz.tsx
+++ b/src/widgets/Quiz/Quiz.tsx
@@ -1,0 +1,79 @@
+import { useState, type FC } from "react";
+import { Button, Header, Text } from "@chernyshovaalexandra/mtsui";
+
+export interface QuizQuestion {
+  question: string;
+  options: string[];
+  correct: number;
+}
+
+interface QuizProps {
+  questions: QuizQuestion[];
+}
+
+export const Quiz: FC<QuizProps> = ({ questions }) => {
+  const [current, setCurrent] = useState(0);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [answered, setAnswered] = useState(false);
+
+  if (current >= questions.length) {
+    return <Text variant="P4-Regular-Text">Тест завершен</Text>;
+  }
+
+  const question = questions[current];
+
+  const handleCheck = () => {
+    if (selected !== null) {
+      setAnswered(true);
+    }
+  };
+
+  const handleNext = () => {
+    setAnswered(false);
+    setSelected(null);
+    setCurrent((prev) => prev + 1);
+  };
+
+  return (
+    <div style={{ marginTop: 24 }}>
+      <Header as="h3" variant="H3-Wide">
+        {question.question}
+      </Header>
+      <fieldset style={{ marginTop: 16, border: 0, padding: 0 }}>
+        <legend className="sr-only">{question.question}</legend>
+        {question.options.map((opt, index) => (
+          <label key={index} style={{ display: "block", marginBottom: 8 }}>
+            <input
+              type="radio"
+              name={`question-${current}`}
+              checked={selected === index}
+              onChange={() => setSelected(index)}
+            />
+            {opt}
+          </label>
+        ))}
+      </fieldset>
+      {!answered ? (
+        <Button
+          variant="primary"
+          onClick={handleCheck}
+          disabled={selected === null}
+          style={{ marginTop: 16 }}
+        >
+          Ответить
+        </Button>
+      ) : (
+        <div style={{ marginTop: 16 }}>
+          <Text variant="P4-Regular-Text" style={{ marginBottom: 16 }}>
+            {selected === question.correct ? "Верно!" : "Неверно"}
+          </Text>
+          {current < questions.length - 1 && (
+            <Button variant="primary" onClick={handleNext}>
+              Следующий вопрос
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/widgets/Quiz/index.ts
+++ b/src/widgets/Quiz/index.ts
@@ -1,0 +1,2 @@
+export * from "./Quiz";
+export type { QuizQuestion } from "./Quiz";

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -4,3 +4,4 @@ export * from "./SuccessStoriesCarousel/SuccessStoriesCarousel";
 export * from "./RandomCoffeeBlock/RandomCoffeeBlock";
 export * from "./VacancyGrid/VacancyGrid";
 export * from "./ModalRoot";
+export * from "./Quiz";


### PR DESCRIPTION
## Summary
- implement reusable `Quiz` widget
- export widget from the widgets barrel
- add question mocks for activity pages
- display quiz on Marketing, Service, IT and Finance pages

## Testing
- `pnpm lint` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887868bc8308323924c0bc1449bf47a